### PR TITLE
Track completion status of timeouts and allow retrieval of scheduled and completed timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ var myTimeoutId = setTimeout(myFunc, 5000);
 timeoutCollection.get(0);
 timeoutCollection.getById(myTimeoutId); //Both returning the timeout object created
 
-timeoutCollection.remove(myTimeoutId);
-timeoutCollection.getAll(); // []
+timeoutCollection.getScheduled(); //Returns an array of timeout objects that have not yet executed
+timeoutCollection.getCompleted(); //Returns an array of timeout objects that have been executed
+timeoutCollection.getAll(); //Returns an array of timeout objects
 
+timeoutCollection.remove(myTimeoutId);
+timeoutCollection.removeAll();
 ```
 
 Basically, you should inject the library script from in place you would like the collection to work on.

--- a/src/timeout/timeout-collection.model.ts
+++ b/src/timeout/timeout-collection.model.ts
@@ -11,13 +11,6 @@ export class TimeoutCollection {
 		return id;
 	}
 
-	private _getWrappedHandler(handler: Function): Function {
-		return (() => {
-			this._timeoutCollection[this._getTimeoutIndexByHandler(handler)].status = TimeoutStatus.Completed;
-			return handler.apply(window);
-		});
-	}
-
 	public remove(id: number): void {
 		let timeoutIndex = this._getTimeoutIndexById(id);
 
@@ -34,13 +27,13 @@ export class TimeoutCollection {
 
 	public getScheduled(): Timeout[] {
 		return this._timeoutCollection.filter((value: Timeout) => {
-			return value.status == TimeoutStatus.Scheduled;
+			return value.status === TimeoutStatus.Scheduled;
 		});
 	}
 
 	public getCompleted(): Timeout[] {
 		return this._timeoutCollection.filter((value: Timeout) => {
-			return value.status == TimeoutStatus.Completed;
+			return value.status === TimeoutStatus.Completed;
 		});
 	}
 
@@ -58,6 +51,14 @@ export class TimeoutCollection {
 		});
 
 		this._timeoutCollection = [];
+	}
+
+	private _getWrappedHandler(handler: Function): Function {
+		return (() => {
+			this._timeoutCollection[this._getTimeoutIndexByHandler(handler)].status = TimeoutStatus.Completed;
+			
+			return handler.apply(window);
+		});
 	}
 
 	private _getTimeoutIndexById(timeoutId: number): number {

--- a/src/timeout/timeout-collection.model.ts
+++ b/src/timeout/timeout-collection.model.ts
@@ -1,14 +1,21 @@
 import { originalClearTimeout, originalSetTimeout } from '../overrides/override'
+import { TimeoutStatus } from './timeout-status.model';
 import { Timeout } from './timeout.model';
 
 export class TimeoutCollection {
 	private _timeoutCollection: Timeout[] = [];
 
 	public add(handler: any, timeout?: any, ...args: any[]) {
-		let id = originalSetTimeout.apply(window, [handler, timeout, args]);
-		this._timeoutCollection.push({id, handler, timeout, arguments: args, timestamp: Date.now()});
-
+		let id = originalSetTimeout.apply(window, [this._getWrappedHandler(handler), timeout, args]);
+		this._timeoutCollection.push(new Timeout(id, handler, timeout, args));
 		return id;
+	}
+
+	private _getWrappedHandler(handler: Function): Function {
+		return (() => {
+			this._timeoutCollection[this._getTimeoutIndexByHandler(handler)].status = TimeoutStatus.Completed;
+			return handler.apply(window);
+		});
 	}
 
 	public remove(id: number): void {
@@ -23,6 +30,18 @@ export class TimeoutCollection {
 
 	public get(index: number): Timeout {
 		return this._timeoutCollection[index];
+	}
+
+	public getScheduled(): Timeout[] {
+		return this._timeoutCollection.filter((value: Timeout) => {
+			return value.status == TimeoutStatus.Scheduled;
+		});
+	}
+
+	public getCompleted(): Timeout[] {
+		return this._timeoutCollection.filter((value: Timeout) => {
+			return value.status == TimeoutStatus.Completed;
+		});
 	}
 
 	public getAll(): Timeout[] {
@@ -44,6 +63,16 @@ export class TimeoutCollection {
 	private _getTimeoutIndexById(timeoutId: number): number {
 		for (let i = 0; i < this._timeoutCollection.length; i++) {
 			if (this._timeoutCollection[i].id === timeoutId) {
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	private _getTimeoutIndexByHandler(handler: Function): number {
+		for (let i = 0; i < this._timeoutCollection.length; i++) {
+			if (this._timeoutCollection[i].handler === handler) {
 				return i;
 			}
 		}

--- a/src/timeout/timeout-status.model.ts
+++ b/src/timeout/timeout-status.model.ts
@@ -1,4 +1,4 @@
 export enum TimeoutStatus {
   Scheduled,
-  Completed,
+  Completed
 }

--- a/src/timeout/timeout-status.model.ts
+++ b/src/timeout/timeout-status.model.ts
@@ -1,0 +1,4 @@
+export enum TimeoutStatus {
+  Scheduled,
+  Completed,
+}

--- a/src/timeout/timeout.model.ts
+++ b/src/timeout/timeout.model.ts
@@ -1,7 +1,19 @@
-export abstract class Timeout {
+import { TimeoutStatus } from './timeout-status.model';
+
+export class Timeout {
     id: number;
     handler: Function;
     timeout: number;
     arguments: any[];
     timestamp: number;
+    status: TimeoutStatus;
+
+    constructor(id: number, handler: Function, timeout: number, ...args: any[]) {
+        this.id = id;
+        this.handler = handler;
+        this.timeout = timeout;
+        this.arguments = args;
+        this.timestamp = Date.now();
+        this.status = TimeoutStatus.Scheduled;
+    }
 }

--- a/src/timeout/timeout.model.ts
+++ b/src/timeout/timeout.model.ts
@@ -1,19 +1,28 @@
 import { TimeoutStatus } from './timeout-status.model';
 
 export class Timeout {
-    id: number;
+    uuid: string;
     handler: Function;
     timeout: number;
     arguments: any[];
+    id: number;
     timestamp: number;
     status: TimeoutStatus;
 
-    constructor(id: number, handler: Function, timeout: number, ...args: any[]) {
-        this.id = id;
+    constructor(handler: Function, timeout: number, ...args: any[]) {
+        this.uuid = this._generateUuid();
         this.handler = handler;
         this.timeout = timeout;
         this.arguments = args;
+        this.id = null;
         this.timestamp = Date.now();
         this.status = TimeoutStatus.Scheduled;
+    }
+
+    private _generateUuid(): string {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
     }
 }


### PR DESCRIPTION
This adds two new methods to the `timeoutCollection` object: `getScheduled` and `getCompleted`. The `Timeout` object has been expanded to have a `status` field, and has been given a constructor to quickly/easily set the `timestamp` and `status`. 

I'm not fully confident that my `_getWrappedHandler` method is the cleanest implementation of marking the `Timeout` complete when triggered, so I welcome your comments, suggestions, or a different implementation. Additionally, I suspect that it doesn't respect any additional parameters passed into timeout, but don't have a valid use case with which to test. Perhaps you can double-check me here, and maybe offer a better solution?

Refs #3